### PR TITLE
Added standard maven deploy plugin to allow deploy artifact to local repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 
@@ -35,7 +36,7 @@ allprojects {
         releaseRepoName = 'exoplayer'
         releaseUserOrg = 'google'
         releaseGroupId = 'com.google.android.exoplayer'
-        releaseVersion = 'r2.1.1'
+        releaseVersion = 'r2.1.2-SNAPSHOT'
         releaseWebsite = 'https://github.com/google/ExoPlayer'
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@ import com.android.builder.core.BuilderConstants
 
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
@@ -95,3 +96,8 @@ publish {
     version = releaseVersion
     website = releaseWebsite
 }
+
+// default maven deploy/install setup
+group = releaseGroupId
+archivesBaseName = releaseRepoName
+version = releaseVersion


### PR DESCRIPTION
It is not fully default maven deploy plugin, but its [modification](https://github.com/dcendents/android-maven-gradle-plugin) to better compatibility with Android AAR.

By "gradlew :library:install" it is possible to publish any version of ExoPlayer library to local repo and then use it project just by adding mavenLocal() to the repositories section.

Maybe it is not ideal way how to implement it, because you are creating custom variables like releaseVersion in the project.ext space, instead of using directly existing project variable "version", but I don't wanted to do bigger changes. This works good.

Just normally in the dev branch should be -SNAPSHOT in the version to distinguish dev build from the released version in the bintray. -SNAPSHOT should be removed just for the tagged commit which will be deployed to  bintray.
